### PR TITLE
Inflector::underscoreで大文字の1文字以上連続も単語とみなすようにした

### DIFF
--- a/core/inflector.php
+++ b/core/inflector.php
@@ -8,6 +8,15 @@ class Inflector
 
     public static function underscore($str)
     {
-        return strtolower(preg_replace('/(?<=\\w)([A-Z]+)/', '_\\1', $str));
+        /* [A-Z]+ と [A-Z][a-z]* を単語とみなす。
+         * つまり、単語の境界は
+         *     [a-z][A-Z]
+         *          ^ココ
+         * または
+         *     [A-Z][A-Z][a-z]
+         *          ^ココ
+         * となる。
+         */
+        return strtolower(preg_replace('/([a-z]+(?=[A-Z])|[A-Z]+(?=[A-Z][a-z]))/', '\\1_', $str));
     }
 }

--- a/tests/inflector_test.php
+++ b/tests/inflector_test.php
@@ -13,9 +13,11 @@ class InflectorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('plain_text', Inflector::underscore('PlainText'));
         $this->assertEquals('foo_bar_hoge', Inflector::underscore('FooBarHoge'));
         $this->assertEquals('foo', Inflector::underscore('Foo'));
-        // TODO:
-        //$this->assertEquals('db', Inflector::underscore('DB'));
-        //$this->assertEquals('dbo', Inflector::underscore('DBO'));
-        //$this->assertEquals('db_object', Inflector::underscore('DBObject'));
+        $this->assertEquals('db', Inflector::underscore('DB'));
+        $this->assertEquals('dbo', Inflector::underscore('DBO'));
+        $this->assertEquals('db_object', Inflector::underscore('DBObject'));
+        $this->assertEquals('a_to_z', Inflector::underscore('AToZ'));
+        $this->assertEquals('parse_url', Inflector::underscore('ParseURL'));
+        $this->assertEquals('take_a_look', Inflector::underscore('TakeALook'));
     }
 }


### PR DESCRIPTION
「TakeALook」のようなクラス名に対してunderscore関数が期待通りに動いていなかったのを修正しました。
