### PR TITLE
use short array syntax

### DIFF
--- a/core/dispatcher.php
+++ b/core/dispatcher.php
@@ -34,7 +34,7 @@ class Dispatcher
         $action_name = array_pop($action);
         $controller_name = join("_", $action);
 
-        return array($controller_name, $action_name);
+        return [$controller_name, $action_name];
     }
 
     /**

--- a/core/model.php
+++ b/core/model.php
@@ -5,7 +5,7 @@ class Model
     public $validation;
     public $validation_errors;
 
-    public function __construct(array $data = array())
+    public function __construct(array $data = [])
     {
         $this->set($data);
     }
@@ -44,9 +44,9 @@ class Model
                 $validate_func = array_shift($args);
                 if (method_exists($this, $validate_func)) {
                     // 検証メソッドがモデルに存在するとき実行
-                    $valid = call_user_func_array(array($this, $validate_func), array_merge(array($v), $args));
+                    $valid = call_user_func_array([$this, $validate_func], array_merge([$v], $args));
                 } elseif (function_exists($validate_func)) {
-                    $valid = call_user_func_array($validate_func, array_merge(array($v), $args));
+                    $valid = call_user_func_array($validate_func, array_merge([$v], $args));
                 } else {
                     // 存在しない検証メソッドのときエラー
                     throw new DCException("{$validate_func} does not exist");

--- a/core/view.php
+++ b/core/view.php
@@ -2,7 +2,7 @@
 class View
 {
     public $controller;             // コントローラへの参照
-    public $vars = array();         // 展開する変数
+    public $vars = [];         // 展開する変数
     public static $ext = '.php';
 
     public function __construct($controller)

--- a/tests/controller_test.php
+++ b/tests/controller_test.php
@@ -19,11 +19,11 @@ class ControllerTest extends PHPUnit_Framework_TestCase
     {
         $controller = new Controller('');
         $controller->set('foo', 100);
-        $controller->set('bar', array(1, 2));
+        $controller->set('bar', [1, 2]);
         $this->assertEquals(100, $controller->view->vars['foo']);
-        $this->assertEquals(array(1, 2), $controller->view->vars['bar']);
+        $this->assertEquals([1, 2], $controller->view->vars['bar']);
 
-        $controller->set(array('foo' => 200));
+        $controller->set(['foo' => 200]);
         $this->assertEquals(200, $controller->view->vars['foo']);
     }
 }

--- a/tests/dispatcher_test.php
+++ b/tests/dispatcher_test.php
@@ -5,9 +5,9 @@ class DispatcherTest extends PHPUnit_Framework_TestCase
 {
     public function test_parseAction()
     {
-        $this->assertEquals(array('top', 'index'), Dispatcher::parseAction('top/index'));
-        $this->assertEquals(array('player', 'view_record'), Dispatcher::parseAction('player/view_record'));
-        $this->assertEquals(array('event_top', 'index'), Dispatcher::parseAction('event/top/index'));
+        $this->assertEquals(['top', 'index'], Dispatcher::parseAction('top/index'));
+        $this->assertEquals(['player', 'view_record'], Dispatcher::parseAction('player/view_record'));
+        $this->assertEquals(['event_top', 'index'], Dispatcher::parseAction('event/top/index'));
 
     }
 

--- a/tests/model_test.php
+++ b/tests/model_test.php
@@ -6,7 +6,7 @@ class ModelTest extends PHPUnit_Framework_TestCase
     public function test_set()
     {
         $model = new Model;
-        $model->set(array('foo' => 200, 'bar' => 'test'));
+        $model->set(['foo' => 200, 'bar' => 'test']);
         $this->assertEquals(200, $model->foo);
         $this->assertEquals('test', $model->bar);
     }
@@ -38,11 +38,11 @@ class ModelTest extends PHPUnit_Framework_TestCase
 
 class TestPlayer extends Model
 {
-    public $validation = array(
-        'name' => array(
-            'between' => array('validate_between', 3, 16),
-        ),
-    );
+    public $validation = [
+        'name' => [
+            'between' => ['validate_between', 3, 16],
+        ],
+    ];
 }
 
 function validate_between($check, $min, $max)

--- a/tests/param_test.php
+++ b/tests/param_test.php
@@ -8,8 +8,8 @@ class ParamTest extends PHPUnit_Framework_TestCase
         $_REQUEST['foo'] = 200;
         $this->assertEquals(200, Param::get('foo'));
 
-        $_REQUEST['foo'] = array('a', 'b');
-        $this->assertEquals(array('a', 'b'), Param::get('foo'));
+        $_REQUEST['foo'] = ['a', 'b'];
+        $this->assertEquals(['a', 'b'], Param::get('foo'));
 
         $this->assertTrue(is_null(Param::get('bar')));
 
@@ -18,9 +18,9 @@ class ParamTest extends PHPUnit_Framework_TestCase
 
     public function test_params()
     {
-        $this->assertEquals(array(), Param::params());
+        $this->assertEquals([], Param::params());
 
         $_REQUEST['foo'] = 100;
-        $this->assertEquals(array('foo' => 100), Param::params());
+        $this->assertEquals(['foo' => 100], Param::params());
     }
 }


### PR DESCRIPTION
~~PHP 5.3がEOLになって久しいので、~~ short array syntaxを適用しました。

このPRを適用するとPHP5.3以下で動かなくなるので、#13 も合わせて適用する必要があるかと思います。
よろしくお願いいたします。

コマンド:
```
$ php-cs-fixer fix . --fixers=short_array_syntax
```

