### PR TITLE
Use Late Static Bindings

### DIFF
--- a/core/controller.php
+++ b/core/controller.php
@@ -25,7 +25,7 @@ class Controller
 
     public function dispatchAction()
     {
-        if (!self::isAction($this->action)) {
+        if (!static::isAction($this->action)) {
             // アクション名が予約語などで正しくないとき
             throw new DCException('invalid action name');
         } 

--- a/core/dispatcher.php
+++ b/core/dispatcher.php
@@ -3,9 +3,9 @@ class Dispatcher
 {
     public static function invoke()
     {
-        list($controller_name, $action_name) = self::parseAction(Param::get(DC_ACTION));
+        list($controller_name, $action_name) = static::parseAction(Param::get(DC_ACTION));
 
-        $controller = self::getController($controller_name);
+        $controller = static::getController($controller_name);
 
         $controller->action = $action_name;
         $controller->beforeFilter();

--- a/core/view.php
+++ b/core/view.php
@@ -24,11 +24,11 @@ class View
     {
         $action = is_null($action) ? $this->controller->action : $action;
         if (strpos($action, '/') === false) {
-            $view_filename = VIEWS_DIR . $this->controller->name . '/' . $action . self::$ext;
+            $view_filename = VIEWS_DIR . $this->controller->name . '/' . $action . static::$ext;
         } else {
-            $view_filename = VIEWS_DIR . $action . self::$ext;
+            $view_filename = VIEWS_DIR . $action . static::$ext;
         }
-        $content = self::extract($view_filename, $this->vars);
+        $content = static::extract($view_filename, $this->vars);
         $this->controller->output .= $content;
     }
 


### PR DESCRIPTION
Want to use `static::` instead of `self::` to access to static members.

In core classes (e.g., Model, Controller, etc.), `self::` is used to access to their static members.
I want to add `AppDispatcher` and customise the behaviour of `Dispatcher`, but I had to re-implement their methods because of `self::`.

Please merge this if there're no concern about using `static::`.