### PR TITLE
Travis CIでエラーがでる問題の一次対処

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.2
   - 5.3
   - 5.4
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ php:
   - 7.0
 
 before_install:
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]]; then composer require --dev --no-update phpunit/phpunit ~4; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]]; then composer require --dev --no-update phpunit/phpunit; fi
 
-script: phpunit -v --coverage-text -c ./tests/phpunit.xml
+script:
+  - phpunit --version
+  - phpunit --coverage-text -c ./tests/phpunit.xml
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 5.6
   - 7.0
 
-script: phpunit --coverage-text -c ./tests/phpunit.xml
+script: phpunit -v --coverage-text -c ./tests/phpunit.xml
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7.0
 
 before_install:
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]]; then composer require --dev --no-update phpunit/phpunit; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]]; then composer require --dev --no-update phpunit/phpunit ^4.8.35; fi
 
 script:
   - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,13 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
 
-before_install:
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]]; then composer require --dev --no-update phpunit/phpunit ^4.8.35; fi
-
 script:
-  - phpunit --version
-  - phpunit --coverage-text -c ./tests/phpunit.xml
+  - phpunit -v --coverage-text -c ./tests/phpunit.xml
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ php:
   - 5.6
   - 7.0
 
+before_install:
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]]; then composer require --dev --no-update phpunit/phpunit ~4; fi
+
 script: phpunit -v --coverage-text -c ./tests/phpunit.xml
 
 matrix:

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,3 +4,8 @@ error_reporting(E_ALL | E_STRICT);
 define('ROOT_DIR', dirname(dirname(__FILE__)).'/');
 define('APP_DIR', ROOT_DIR.'app/');
 require_once ROOT_DIR.'dietcake.php';
+
+// backward compatibility for php 5.5 and low (with phpunit < v.6)
+if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,3 +9,7 @@ require_once ROOT_DIR.'dietcake.php';
 if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
     class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
 }
+
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase')) {
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+}

--- a/tests/controller_test.php
+++ b/tests/controller_test.php
@@ -1,7 +1,9 @@
 <?php
 require_once dirname(__FILE__).'/bootstrap.php';
 
-class ControllerTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ControllerTest extends TestCase
 {
     public function test_isAction()
     {

--- a/tests/dispatcher_test.php
+++ b/tests/dispatcher_test.php
@@ -12,9 +12,11 @@ class DispatcherTest extends TestCase
         $this->assertEquals(array('event_top', 'index'), Dispatcher::parseAction('event/top/index'));
     }
 
+    /**
+     * @expectedException DCException
+     */
     public function test_parseAction_02()
     {
-        $this->setExpectedException('DCException', 'invalid url format');
         Dispatcher::parseAction('top');
     }
 
@@ -23,9 +25,11 @@ class DispatcherTest extends TestCase
         $this->assertTrue(Dispatcher::getController('hello') instanceof HelloController);
     }
 
+    /**
+     * @expectedException DCException
+     */
     public function test_getController_02()
     {
-        $this->setExpectedException('DCException', 'FooController is not found');
         Dispatcher::getController('foo');
     }
 }

--- a/tests/dispatcher_test.php
+++ b/tests/dispatcher_test.php
@@ -1,14 +1,15 @@
 <?php
 require_once dirname(__FILE__).'/bootstrap.php';
 
-class DispatcherTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DispatcherTest extends TestCase
 {
     public function test_parseAction()
     {
         $this->assertEquals(array('top', 'index'), Dispatcher::parseAction('top/index'));
         $this->assertEquals(array('player', 'view_record'), Dispatcher::parseAction('player/view_record'));
         $this->assertEquals(array('event_top', 'index'), Dispatcher::parseAction('event/top/index'));
-
     }
 
     public function test_parseAction_02()

--- a/tests/inflector_test.php
+++ b/tests/inflector_test.php
@@ -1,7 +1,9 @@
 <?php
 require_once dirname(__FILE__).'/bootstrap.php';
 
-class InflectorTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class InflectorTest extends TestCase
 {
     public function test_camelize()
     {

--- a/tests/model_test.php
+++ b/tests/model_test.php
@@ -1,7 +1,9 @@
 <?php
 require_once dirname(__FILE__).'/bootstrap.php';
 
-class ModelTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelTest extends TestCase
 {
     public function test_set()
     {

--- a/tests/param_test.php
+++ b/tests/param_test.php
@@ -1,7 +1,9 @@
 <?php
 require_once dirname(__FILE__).'/bootstrap.php';
 
-class ParamTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ParamTest extends TestCase
 {
     public function test_get()
     {

--- a/tests/param_test.php
+++ b/tests/param_test.php
@@ -10,8 +10,8 @@ class ParamTest extends TestCase
         $_REQUEST['foo'] = 200;
         $this->assertEquals(200, Param::get('foo'));
 
-        $_REQUEST['foo'] = array('a', 'b');
-        $this->assertEquals(array('a', 'b'), Param::get('foo'));
+        $_REQUEST['foo'] = ['a', 'b'];
+        $this->assertEquals(['a', 'b'], Param::get('foo'));
 
         $this->assertTrue(is_null(Param::get('bar')));
 
@@ -20,9 +20,11 @@ class ParamTest extends TestCase
 
     public function test_params()
     {
-        $this->assertEquals(array(), Param::params());
+        $_REQUEST = [];
+
+        $this->assertEquals([], Param::params());
 
         $_REQUEST['foo'] = 100;
-        $this->assertEquals(array('foo' => 100), Param::params());
+        $this->assertEquals(['foo' => 100], Param::params());
     }
 }


### PR DESCRIPTION
#18  を取り込んだ結果、 PHP5.2 と PHP7 の Travis CI によるユニットテストがfailするようになった。
PHP5.2がfailするのはstatic:: が 5.3以降の為なので、サポートを切って対応したが、PHP7が fail するのは、Travis CIが持っているphpunitのバージョンがphp7の時は 6系で5系と互換性のない部分があるため。

最新のバージョンでのテストがfailするのはまずいのでphpunit5系とphpunit6系で動作するように書き換えたが、今度は5.3でのテストがfailするようになってしまった。

Travis CIが持っているphpのバージョンとphpunitを調べると、PHP5.3はForwardCompatibilityを持つバージョンのphpunitを持っていないため、phpunit6系と共存するのは(composerで都度インストールしない限り)不可能と分かった。

PHP7での動作を優先して一旦5.3を切った状態でgreenになるようにする。

今後の修正でcomposer化して、都度phpunitをインストールする形にしたい。

以下はTravis CiのPHPバージョンとPHPUnitのバージョン一覧。
```
php7 -> php 7.0.19 / phpunit 6.1.3
php5.6 -> php 5.6.30 / phpunit 5.7.15
php5.5 -> php 5.5.38 / phpunit 4.8.27
php5.4 -> php 5.4.45 / phpunit 4.8.35
php5.3 -> php 5.3.29 / phpunit 4.8.18 ( -v ででてこないので —versionでだした)
```
