### PR TITLE
Use container-based image on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: false
 
 php:
   - 5.4


### PR DESCRIPTION
Currently we use GCE image on Travis CI. However, these images takes 20-50s for boot time.

Container-based image has faster boot time, so I recommend to switch build environment to container-based.