### PR TITLE
use multi phpunit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Super fast MVC framework for PHP",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
     },
     "license": "MIT",
     "authors": [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,12 +4,3 @@ error_reporting(E_ALL | E_STRICT);
 define('ROOT_DIR', dirname(dirname(__FILE__)).'/');
 define('APP_DIR', ROOT_DIR.'app/');
 require_once ROOT_DIR.'dietcake.php';
-
-// backward compatibility for php 5.5 and low (with phpunit < v.6)
-if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
-    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
-}
-
-if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase')) {
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-}


### PR DESCRIPTION
* PHP処理系バージョンに応じて、異なるPHPUnitがインストールされるようにする
* それによりclass_aliasが不要になるので削除。(`PHPUnit\Framework\TestCase` は必ず存在するので)

参考: https://qiita.com/tanakahisateru/items/ef9f4c9b8ca39e6d0ed8

