### PR TITLE
dirname(__FILE__) -> __DIR__

### DIFF
--- a/dietcake.php
+++ b/dietcake.php
@@ -10,7 +10,7 @@ mb_internal_encoding('UTF-8');
 define('TIME_START', microtime(true));
 define('DC_ACTION', 'dc_action');
 
-define('DC_DIR', dirname(__FILE__).'/');
+define('DC_DIR', __DIR__.'/');
 define('DC_CORE_DIR', DC_DIR.'core/');
 define('CONFIG_DIR', APP_DIR.'config/');
 define('CONTROLLERS_DIR', APP_DIR.'controllers/');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 error_reporting(E_ALL | E_STRICT);
 
-define('ROOT_DIR', dirname(dirname(__FILE__)).'/');
+define('ROOT_DIR', dirname(__DIR__).'/');
 define('APP_DIR', ROOT_DIR.'app/');
 require_once ROOT_DIR.'dietcake.php';

--- a/tests/controller_test.php
+++ b/tests/controller_test.php
@@ -1,5 +1,5 @@
 <?php
-require_once dirname(__FILE__).'/bootstrap.php';
+require_once __DIR__.'/bootstrap.php';
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/dispatcher_test.php
+++ b/tests/dispatcher_test.php
@@ -1,5 +1,5 @@
 <?php
-require_once dirname(__FILE__).'/bootstrap.php';
+require_once __DIR__.'/bootstrap.php';
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/inflector_test.php
+++ b/tests/inflector_test.php
@@ -1,5 +1,5 @@
 <?php
-require_once dirname(__FILE__).'/bootstrap.php';
+require_once __DIR__.'/bootstrap.php';
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/model_test.php
+++ b/tests/model_test.php
@@ -1,5 +1,5 @@
 <?php
-require_once dirname(__FILE__).'/bootstrap.php';
+require_once __DIR__.'/bootstrap.php';
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/param_test.php
+++ b/tests/param_test.php
@@ -1,5 +1,5 @@
 <?php
-require_once dirname(__FILE__).'/bootstrap.php';
+require_once __DIR__.'/bootstrap.php';
 
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
PHP 5.2 をサポートしなくなったので、`__DIR__` が使えます。

http://php.net/manual/ja/language.constants.predefined.php