### PR TITLE
Remove hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 script:
   - composer install


### PR DESCRIPTION
c.f. https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html

HHVMはもうPHPをサポートしなくなるので、削除してよいかと思います。