### PR TITLE
Fix underscore() to treat digits as word boundaries (e.g. FooV2Bar → foo_v2_bar)

### DIFF
--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -20,13 +20,13 @@ class Inflector
     {
         /* [A-Z]+ と [A-Z][a-z]* を単語とみなす。
          * つまり、単語の境界は
-         *     [a-z][A-Z]
-         *          ^ココ
+         *     [a-z0-9][A-Z]
+         *             ^ココ
          * または
          *     [A-Z][A-Z][a-z]
          *          ^ココ
          * となる。
          */
-        return strtolower(preg_replace('/([a-z]+(?=[A-Z])|[A-Z]+(?=[A-Z][a-z]))/', '\\1_', $str));
+        return strtolower(preg_replace('/([a-z0-9]+(?=[A-Z])|[A-Z]+(?=[A-Z][a-z]))/', '\\1_', $str));
     }
 }

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -21,5 +21,6 @@ class InflectorTest extends TestCase
         $this->assertEquals('a_to_z', Inflector::underscore('AToZ'));
         $this->assertEquals('parse_url', Inflector::underscore('ParseURL'));
         $this->assertEquals('take_a_look', Inflector::underscore('TakeALook'));
+        $this->assertEquals('foo_v2_bar', Inflector::underscore('FooV2Bar'));
     }
 }


### PR DESCRIPTION
`Inflector::underscore() `で数字と大文字の境界にアンダースコアが挿入されるように修正

例: FooV2Bar → foo_v2bar ❌
修正後: FooV2Bar → foo_v2_bar ✅

変更内容

- src/Inflector.php: 正規表現を [a-z]+ → [a-z0-9]+ に変更し、数字も境界として扱うよう修正。あわせてコメントも更新。
- tests/InflectorTest.php: FooV2Bar → foo_v2_bar のテストケースを追加。